### PR TITLE
FIX: ssl cert setup

### DIFF
--- a/php74.Dockerfile
+++ b/php74.Dockerfile
@@ -19,6 +19,7 @@ RUN apk --update add \
   imagemagick-dev \
   imagemagick \
   postgresql-dev \
+  ca-certificates \
   libzip-dev \
   gettext-dev \
   libxslt-dev \
@@ -51,7 +52,7 @@ RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ 
 
 RUN docker-php-ext-enable imagick redis
 
-RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
+RUN update-ca-certificates
 
 COPY runtime/bootstrap /opt/bootstrap
 COPY runtime/bootstrap.php /opt/bootstrap.php

--- a/php80.Dockerfile
+++ b/php80.Dockerfile
@@ -19,6 +19,7 @@ RUN apk --update add \
   imagemagick-dev \
   imagemagick \
   postgresql-dev \
+  ca-certificates \
   libzip-dev \
   gettext-dev \
   libxslt-dev \
@@ -51,7 +52,7 @@ RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ 
 
 RUN docker-php-ext-enable redis
 
-RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
+RUN update-ca-certificates
 
 COPY runtime/bootstrap /opt/bootstrap
 COPY runtime/bootstrap.php /opt/bootstrap.php

--- a/runtime/php.ini
+++ b/runtime/php.ini
@@ -2,8 +2,9 @@ display_errors=0
 
 memory_limit=2048M
 
-curl.cainfo="/opt/cert.pem"
-openssl.cafile="/opt/cert.pem"
+curl.cainfo="/etc/ssl/cert.pem"
+openssl.cafile="/etc/ssl/cert.pem"
+openssl.capath="/etc/ssl/certs"
 
 expose_php=off
 


### PR DESCRIPTION
This seems to be a more default setup?

Adding `openssl.capath="/etc/ssl/certs"` to the php.ini file was critical to get SSL working for secure database connections. 

Without it, I would get this obtuse error:

```
PDOException
PDO::__construct(): SSL operation failed with code 1. OpenSSL Error messages:
error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed
```

whenever I attempted a database connection with `'sslmode' => 'require'` in database.php for any Laravel 8 application.

I've got it working in my own setup with a custom dockerfile and php.ini, but these changes seemed like they probably belong here as well?

For more context, I was working through this: https://docs.planetscale.com/reference/secure-connections

Planetscale seems really cool (I'm not affiliated with them) since I now have a truly zero-cost, serverless Laravel deployment (database cost was the only remaining fixed monthly expense)