### PR TITLE
Use latest PHP 8.1 image

### DIFF
--- a/php81.Dockerfile
+++ b/php81.Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1.0-fpm-alpine
+FROM php:8.1-fpm-alpine
 
 RUN apk --update add \
   wget \


### PR DESCRIPTION
The current configuration locks the `php:8.1.0-alpine-fpm` image at v8.1.0. This updates the config to use the latest `php:8.1-alpine-fpm` image, allowing the image to use PHP 8.1.x releases.