### PR TITLE
Enable imagick for PHP 8.0 and 8.1 by default

### DIFF
--- a/php80.Dockerfile
+++ b/php80.Dockerfile
@@ -26,7 +26,7 @@ RUN apk --update add \
   rm /var/cache/apk/*
 
 RUN pecl channel-update pecl.php.net && \
-    pecl install mcrypt redis-5.3.2 && \
+    pecl install mcrypt imagick redis-5.3.2 && \
     rm -rf /tmp/pear
 
 RUN docker-php-ext-install \
@@ -49,7 +49,7 @@ RUN docker-php-ext-install \
 RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ && \
     docker-php-ext-install gd
 
-RUN docker-php-ext-enable redis
+RUN docker-php-ext-enable imagick redis
 
 RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
 

--- a/php81.Dockerfile
+++ b/php81.Dockerfile
@@ -26,7 +26,7 @@ RUN apk --update add \
   rm /var/cache/apk/*
 
 RUN pecl channel-update pecl.php.net && \
-    pecl install mcrypt redis-5.3.4 && \
+    pecl install mcrypt imagick redis-5.3.4 && \
     rm -rf /tmp/pear
 
 RUN docker-php-ext-install \
@@ -48,7 +48,7 @@ RUN docker-php-ext-install \
 RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ && \
     docker-php-ext-install gd
 
-RUN docker-php-ext-enable redis
+RUN docker-php-ext-enable imagick redis
 
 RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
 


### PR DESCRIPTION
The existing PHP 7.4 Dockerfile already enables Imagick. While PHP 8.0 and 8.1 install the required APK packages, they don't actually enable the extension.