### PR TITLE
Fix CVE-2022-23308 vulnerability

### DIFF
--- a/php81.Dockerfile
+++ b/php81.Dockerfile
@@ -25,6 +25,8 @@ RUN apk --update add \
   libgcrypt-dev &&\
   rm /var/cache/apk/*
 
+RUN apk --no-cache upgrade libxml2-dev
+
 RUN pecl channel-update pecl.php.net && \
     pecl install mcrypt redis-5.3.4 && \
     rm -rf /tmp/pear


### PR DESCRIPTION
This pull request fixes  CVE-2022-23308 Medium vulnerability (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23308)