### PR TITLE
Adds PHP 8.2 support

### DIFF
--- a/php82.Dockerfile
+++ b/php82.Dockerfile
@@ -1,29 +1,29 @@
 FROM --platform=linux/amd64 php:8.2.0RC3-fpm-alpine
 
 RUN apk --update add \
-  wget \
-  curl \
-  build-base \
-  libmcrypt-dev \
-  libxml2-dev \
-  pcre-dev \
-  zlib-dev \
-  autoconf \
-  oniguruma-dev \
-  openssl \
-  openssl-dev \
-  freetype-dev \
-  libjpeg-turbo-dev \
-  jpeg-dev \
-  libpng-dev \
-  imagemagick-dev \
-  imagemagick \
-  postgresql-dev \
-  libzip-dev \
-  gettext-dev \
-  libxslt-dev \
-  libgcrypt-dev &&\
-  rm /var/cache/apk/*
+    wget \
+    curl \
+    build-base \
+    libmcrypt-dev \
+    libxml2-dev \
+    pcre-dev \
+    zlib-dev \
+    autoconf \
+    oniguruma-dev \
+    openssl \
+    openssl-dev \
+    freetype-dev \
+    libjpeg-turbo-dev \
+    jpeg-dev \
+    libpng-dev \
+    imagemagick-dev \
+    imagemagick \
+    postgresql-dev \
+    libzip-dev \
+    gettext-dev \
+    libxslt-dev \
+    libgcrypt-dev &&\
+    rm /var/cache/apk/*
 
 RUN pecl channel-update pecl.php.net && \
     pecl install mcrypt redis-5.3.7 && \

--- a/php82.Dockerfile
+++ b/php82.Dockerfile
@@ -1,0 +1,64 @@
+FROM --platform=linux/amd64 php:8.2.0RC2-fpm-alpine
+
+RUN apk --update add \
+  wget \
+  curl \
+  build-base \
+  libmcrypt-dev \
+  libxml2-dev \
+  pcre-dev \
+  zlib-dev \
+  autoconf \
+  oniguruma-dev \
+  openssl \
+  openssl-dev \
+  freetype-dev \
+  libjpeg-turbo-dev \
+  jpeg-dev \
+  libpng-dev \
+  imagemagick-dev \
+  imagemagick \
+  postgresql-dev \
+  libzip-dev \
+  gettext-dev \
+  libxslt-dev \
+  libgcrypt-dev &&\
+  rm /var/cache/apk/*
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install mcrypt redis-5.3.7 && \
+    rm -rf /tmp/pear
+
+RUN docker-php-ext-install \
+    mysqli \
+    mbstring \
+    pdo \
+    pdo_mysql \
+    xml \
+    pcntl \
+    bcmath \
+    pdo_pgsql \
+    zip \
+    intl \
+    gettext \
+    soap \
+    # sockets \
+    xsl
+
+RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ && \
+    docker-php-ext-install gd
+
+RUN docker-php-ext-enable redis
+
+RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
+
+COPY runtime/bootstrap /opt/bootstrap
+COPY runtime/bootstrap.php /opt/bootstrap.php
+COPY runtime/php.ini /usr/local/etc/php/php.ini
+
+RUN chmod 755 /opt/bootstrap
+RUN chmod 755 /opt/bootstrap.php
+
+ENTRYPOINT []
+
+CMD /opt/bootstrap

--- a/php82.Dockerfile
+++ b/php82.Dockerfile
@@ -29,6 +29,11 @@ RUN pecl channel-update pecl.php.net && \
     pecl install mcrypt redis-5.3.7 && \
     rm -rf /tmp/pear
 
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/install-php-extensions && \
+    install-php-extensions sockets
+
 RUN docker-php-ext-install \
     mysqli \
     mbstring \
@@ -42,7 +47,6 @@ RUN docker-php-ext-install \
     intl \
     gettext \
     soap \
-    # sockets \
     xsl
 
 RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ && \

--- a/php82.Dockerfile
+++ b/php82.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 php:8.2.0RC2-fpm-alpine
+FROM --platform=linux/amd64 php:8.2.0RC3-fpm-alpine
 
 RUN apk --update add \
   wget \


### PR DESCRIPTION
This PR adds support for PHP 8.2.

Currently, it's set you use PHP 8.2RC3. We should continue to update and test this PR as new release candidates are released in the build up to it's full scheduled release in November.

In order to get this to build, I've had to comment out installation of the `sockets` extension, but looking at the phpinfo output, this seems to be included anyway. I'll continue to dig into this.