### PR TITLE
Add WebP support

### DIFF
--- a/php80.Dockerfile
+++ b/php80.Dockerfile
@@ -16,6 +16,7 @@ RUN apk --update add \
   libjpeg-turbo-dev \
   jpeg-dev \
   libpng-dev \
+  libwebp-dev \
   imagemagick-dev \
   imagemagick \
   postgresql-dev \
@@ -46,7 +47,7 @@ RUN docker-php-ext-install \
     sockets \
     xsl
 
-RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ && \
+RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ --with-webp=/usr/lib/ && \
     docker-php-ext-install gd
 
 RUN docker-php-ext-enable redis

--- a/php81.Dockerfile
+++ b/php81.Dockerfile
@@ -16,6 +16,7 @@ RUN apk --update add \
     libjpeg-turbo-dev \
     jpeg-dev \
     libpng-dev \
+    libwebp-dev \
     imagemagick-dev \
     imagemagick \
     postgresql-dev \
@@ -45,7 +46,7 @@ RUN docker-php-ext-install \
     sockets \
     xsl
 
-RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ && \
+RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ --with-webp=/usr/lib/ && \
     docker-php-ext-install gd
 
 RUN docker-php-ext-enable redis

--- a/php82-arm.Dockerfile
+++ b/php82-arm.Dockerfile
@@ -25,6 +25,7 @@ RUN apk --update add \
     libjpeg-turbo-dev \
     jpeg-dev \
     libpng-dev \
+    libwebp-dev \
     imagemagick-dev \
     imagemagick \
     postgresql-dev \
@@ -55,7 +56,7 @@ RUN docker-php-ext-install \
     sockets \
     xsl
 
-RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ && \
+RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ --with-webp=/usr/lib/ && \
     docker-php-ext-install gd
 
 RUN docker-php-ext-enable redis

--- a/php82.Dockerfile
+++ b/php82.Dockerfile
@@ -16,6 +16,7 @@ RUN apk --update add \
     libjpeg-turbo-dev \
     jpeg-dev \
     libpng-dev \
+    libwebp-dev \
     imagemagick-dev \
     imagemagick \
     postgresql-dev \
@@ -49,7 +50,7 @@ RUN docker-php-ext-install \
     soap \
     xsl
 
-RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ && \
+RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ --with-webp=/usr/lib/ && \
     docker-php-ext-install gd
 
 RUN docker-php-ext-enable redis


### PR DESCRIPTION
This pull request adds WebP support. Without this addition, the following error is triggered:

`Unsupported image type. GD/PHP installation does not support WebP format.`