### PR TITLE
Update redis to 6.1.0

### DIFF
--- a/php83-arm.Dockerfile
+++ b/php83-arm.Dockerfile
@@ -36,7 +36,7 @@ RUN apk --update add \
     rm /var/cache/apk/*
 
 RUN pecl channel-update pecl.php.net && \
-    pecl install mcrypt redis-6.0.1 && \
+    pecl install mcrypt redis-6.1.0 && \
     rm -rf /tmp/pear
 
 RUN docker-php-ext-install \

--- a/php83.Dockerfile
+++ b/php83.Dockerfile
@@ -27,7 +27,7 @@ RUN apk --update add \
     rm /var/cache/apk/*
 
 RUN pecl channel-update pecl.php.net && \
-    pecl install mcrypt redis-6.0.1 && \
+    pecl install mcrypt redis-6.1.0 && \
     rm -rf /tmp/pear
 
 RUN docker-php-ext-install \


### PR DESCRIPTION
Phpredis 6.1.0 is the latest stable version and includes a number of bug fixes including the handling of large cursor values when scanning.

See: https://github.com/phpredis/phpredis/releases/tag/6.1.0