### PR TITLE
Add PHP 8.5 Support

### DIFF
--- a/php85-arm.Dockerfile
+++ b/php85-arm.Dockerfile
@@ -1,0 +1,80 @@
+FROM --platform=linux/arm64 php:8.5-fpm-alpine
+
+ONBUILD ARG __VAPOR_RUNTIME=
+ONBUILD RUN if [ -z "$__VAPOR_RUNTIME" ] ; then \
+    echo "No runtime provided. Please upgrade to the latest version of laravel/vapor-cli." ; \
+    exit 1 ; \
+    elif [ "$__VAPOR_RUNTIME" != "docker-arm" ] ; then \
+    echo "The provided runtime [$__VAPOR_RUNTIME] is not supported by the vapor:php85-arm base image." ; \
+    exit 1 ; \
+    fi
+
+RUN apk --update add \
+    wget \
+    curl \
+    build-base \
+    libmcrypt-dev \
+    libxml2-dev \
+    pcre-dev \
+    zlib-dev \
+    autoconf \
+    oniguruma-dev \
+    openssl \
+    openssl-dev \
+    freetype-dev \
+    libjpeg-turbo-dev \
+    jpeg-dev \
+    libpng-dev \
+    imagemagick-dev \
+    imagemagick \
+    postgresql-dev \
+    libzip-dev \
+    gettext-dev \
+    libxslt-dev \
+    libgcrypt-dev \
+    linux-headers && \
+    rm /var/cache/apk/*
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install redis-6.3.0 && \
+    rm -rf /tmp/pear
+
+RUN docker-php-ext-install \
+    mysqli \
+    mbstring \
+    pdo \
+    pdo_mysql \
+    xml \
+    pcntl \
+    bcmath \
+    pdo_pgsql \
+    zip \
+    intl \
+    gettext \
+    soap \
+    sockets \
+    xsl
+
+RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ && \
+    docker-php-ext-install gd
+
+RUN docker-php-ext-enable redis
+
+RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
+
+COPY runtime/bootstrap /opt/bootstrap
+COPY runtime/bootstrap.php /opt/bootstrap.php
+COPY runtime/php.ini /usr/local/etc/php/php.ini
+
+# Sometimes opcache is already included via /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
+# but we add it if not
+RUN if ! php -m | grep -q "Zend OPcache"; then \
+       echo "zend_extension=opcache.so" >> /usr/local/etc/php/php.ini; \
+   fi
+
+RUN chmod 755 /opt/bootstrap
+RUN chmod 755 /opt/bootstrap.php
+
+ENTRYPOINT []
+
+CMD /opt/bootstrap

--- a/php85.Dockerfile
+++ b/php85.Dockerfile
@@ -1,0 +1,71 @@
+FROM --platform=linux/amd64 php:8.5-fpm-alpine
+
+RUN apk --update add \
+    wget \
+    curl \
+    build-base \
+    libmcrypt-dev \
+    libxml2-dev \
+    pcre-dev \
+    zlib-dev \
+    autoconf \
+    oniguruma-dev \
+    openssl \
+    openssl-dev \
+    freetype-dev \
+    libjpeg-turbo-dev \
+    jpeg-dev \
+    libpng-dev \
+    imagemagick-dev \
+    imagemagick \
+    postgresql-dev \
+    libzip-dev \
+    gettext-dev \
+    libxslt-dev \
+    libgcrypt-dev \
+    linux-headers && \
+    rm /var/cache/apk/*
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install redis-6.3.0 && \
+    rm -rf /tmp/pear
+
+RUN docker-php-ext-install \
+    mysqli \
+    mbstring \
+    pdo \
+    pdo_mysql \
+    xml \
+    pcntl \
+    bcmath \
+    pdo_pgsql \
+    zip \
+    intl \
+    gettext \
+    soap \
+    sockets \
+    xsl
+
+RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ && \
+    docker-php-ext-install gd
+
+RUN docker-php-ext-enable redis
+
+RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
+
+COPY runtime/bootstrap /opt/bootstrap
+COPY runtime/bootstrap.php /opt/bootstrap.php
+COPY runtime/php.ini /usr/local/etc/php/php.ini
+
+# Sometimes opcache is already included via /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
+# but we add it if not
+RUN if ! php -m | grep -q "Zend OPcache"; then \
+       echo "zend_extension=opcache.so" >> /usr/local/etc/php/php.ini; \
+   fi
+
+RUN chmod 755 /opt/bootstrap
+RUN chmod 755 /opt/bootstrap.php
+
+ENTRYPOINT []
+
+CMD /opt/bootstrap

--- a/test.sh
+++ b/test.sh
@@ -4,7 +4,7 @@ set -e
 
 BUILD=$1
 
-PHP_VERSIONS=("php82" "php82-arm" "php83" "php83-arm" "php84" "php84-arm")
+PHP_VERSIONS=("php82" "php82-arm" "php83" "php83-arm" "php84" "php84-arm" "php85" "php85-arm")
 
 if [ -n "$BUILD" ]; then
   for phpVersion in "${PHP_VERSIONS[@]}"; do


### PR DESCRIPTION
## Description of Changes

* Add Dockerfiles for `PHP8.5` and `PHP8.5-arm`
* Add new versions to `test.sh`

## Notes
* These are copied from the PHP 8.4 files with the version bumped to 8.5
* The only change I needed to make was to bump PhpRedis from `6.1.0` to `6.3.0`, as there was a build error with PHP8.5 which was resolved in PhpRedis [6.3.0-RC1](https://github.com/phpredis/phpredis/releases/tag/6.3.0RC1)
* Both containers built successfully (locally) using `build.sh` but are otherwise entirely untested
* Please feel free to close this PR if it isn't needed