### PR TITLE
Add Relay extension to base images

### DIFF
--- a/php80.Dockerfile
+++ b/php80.Dockerfile
@@ -51,6 +51,9 @@ RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ 
 
 RUN docker-php-ext-enable redis
 
+COPY --from=mlocati/php-extension-installer:2 /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions relay-0.30.0
+
 RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
 
 COPY runtime/bootstrap /opt/bootstrap

--- a/php81.Dockerfile
+++ b/php81.Dockerfile
@@ -50,6 +50,9 @@ RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ 
 
 RUN docker-php-ext-enable redis
 
+COPY --from=mlocati/php-extension-installer:2 /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions relay-0.30.0
+
 RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
 
 COPY runtime/bootstrap /opt/bootstrap

--- a/php82-arm.Dockerfile
+++ b/php82-arm.Dockerfile
@@ -60,6 +60,9 @@ RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ 
 
 RUN docker-php-ext-enable redis
 
+COPY --from=mlocati/php-extension-installer:2 /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions relay-0.30.0
+
 RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
 
 COPY runtime/bootstrap /opt/bootstrap

--- a/php82.Dockerfile
+++ b/php82.Dockerfile
@@ -51,6 +51,9 @@ RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ 
 
 RUN docker-php-ext-enable redis
 
+COPY --from=mlocati/php-extension-installer:2 /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions relay-0.30.0
+
 RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
 
 COPY runtime/bootstrap /opt/bootstrap

--- a/php83-arm.Dockerfile
+++ b/php83-arm.Dockerfile
@@ -60,6 +60,9 @@ RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ 
 
 RUN docker-php-ext-enable redis
 
+COPY --from=mlocati/php-extension-installer:2 /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions relay-0.30.0
+
 RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
 
 COPY runtime/bootstrap /opt/bootstrap

--- a/php83.Dockerfile
+++ b/php83.Dockerfile
@@ -51,6 +51,9 @@ RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ 
 
 RUN docker-php-ext-enable redis
 
+COPY --from=mlocati/php-extension-installer:2 /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions relay-0.30.0
+
 RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
 
 COPY runtime/bootstrap /opt/bootstrap

--- a/php84-arm.Dockerfile
+++ b/php84-arm.Dockerfile
@@ -60,6 +60,9 @@ RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ 
 
 RUN docker-php-ext-enable redis
 
+COPY --from=mlocati/php-extension-installer:2 /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions relay-0.30.0
+
 RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
 
 COPY runtime/bootstrap /opt/bootstrap

--- a/php84.Dockerfile
+++ b/php84.Dockerfile
@@ -51,6 +51,9 @@ RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ 
 
 RUN docker-php-ext-enable redis
 
+COPY --from=mlocati/php-extension-installer:2 /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions relay-0.30.0
+
 RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
 
 COPY runtime/bootstrap /opt/bootstrap

--- a/php85-arm.Dockerfile
+++ b/php85-arm.Dockerfile
@@ -60,6 +60,9 @@ RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ 
 
 RUN docker-php-ext-enable redis
 
+COPY --from=mlocati/php-extension-installer:2 /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions relay-0.30.0
+
 RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
 
 COPY runtime/bootstrap /opt/bootstrap

--- a/php85.Dockerfile
+++ b/php85.Dockerfile
@@ -51,6 +51,9 @@ RUN docker-php-ext-configure gd --with-freetype=/usr/lib/ --with-jpeg=/usr/lib/ 
 
 RUN docker-php-ext-enable redis
 
+COPY --from=mlocati/php-extension-installer:2 /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions relay-0.30.0
+
 RUN cp "/etc/ssl/cert.pem" /opt/cert.pem
 
 COPY runtime/bootstrap /opt/bootstrap


### PR DESCRIPTION
This PR adds support for Relay (https://relay.so), a high-performance, in-memory caching Redis client, alongside the existing phpredis extension in every base image.